### PR TITLE
DM-39107 Deploy to ghcr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,66 @@
+name: CI
+
+"on":
+  merge_group: {}
+  pull_request:
+    branches:
+      - "tickets/*"
+  push:
+    branches-ignore:
+      # These should always correspond to pull requests, so ignore them for
+      # the push trigger and let them be triggered by the pull_request
+      # trigger, avoiding running the workflow twice.  This is a minor
+      # optimization so there's no need to ensure this is comprehensive.
+      - "dependabot/**"
+      - "gh-readonly-queue/**"
+      - "renovate/**"
+    tags:
+      - "*"
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Define the Docker tag
+        id: vars
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
+
+      - name: Print the tag
+        id: print
+        run: echo ${{ steps.vars.outputs.tag }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/lsst-sqre/strimzi-access-operator:${{ steps.vars.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/scripts/docker-tag.sh
+++ b/scripts/docker-tag.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
+
+set -eo pipefail
+
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
+fi


### PR DESCRIPTION
The image repository for strimzi-access-operator isn't public yet, so we'll host images from our fork on ghcr.io.